### PR TITLE
Add superheat tag to biofuel bucket

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -790,6 +790,10 @@ file = "kubejs/data/spelunkery/loot_tables/gameplay/sluice/portal_fluid/passive.
 hash = "f0ecd634b2777064b09442045b4d0ab7d02c6874b8476bb24a3abd2100928d6e"
 
 [[files]]
+file = "kubejs/server_scripts/Kirin Server Scripts/blaze_burner_fuels.js"
+hash = "6e738c78c082e04204d122be71b3bee46d82596ce17183c80200f5da4bb04536"
+
+[[files]]
 file = "kubejs/server_scripts/godforged_tag.js"
 hash = "5ba63d8deeaabdec09788754f9c816a5dafbc1e6e444ea28fc80b5ccf2fd249a"
 

--- a/kubejs/server_scripts/Kirin Server Scripts/blaze_burner_fuels.js
+++ b/kubejs/server_scripts/Kirin Server Scripts/blaze_burner_fuels.js
@@ -1,0 +1,5 @@
+ServerEvents.tags("item", (event) => {
+
+    event.add("create:blaze_burner_fuel/special" ,"createaddition:bioethanol_bucket");
+    event.add("create:blaze_burner_fuel/regular" ,"createaddition:seed_oil_bucket");
+});

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0f71a3b9b9d7a678b08622868e6c277d00d74f32b392292a6415df45ed7c3563"
+hash = "9753479040f8ed80cdb1f24fc8344d22b821cd9e2e55c54d6bea8fb64b453aa5"
 
 [versions]
 fabric = "0.16.14"


### PR DESCRIPTION
Adds tags to biofuel to make it superheat blaze burners without straws. Also makes seed oil an alternative to lava buckets