### PR TITLE
v1.6.5

### DIFF
--- a/config/item_obliterator.json5
+++ b/config/item_obliterator.json5
@@ -41,6 +41,7 @@
         "ae2:matter_cannon",
         "minecraft:bedrock",
         "minecraft:barrier",
+        "farmersrespite:rose_hip_pie"
     ],
     // -----------------------------------------------------------
     // Removes an item if it contains certain nbt tag. If the whole entry (or expression) is present, the item gets removed.

--- a/index.toml
+++ b/index.toml
@@ -2307,7 +2307,7 @@ metafile = true
 
 [[files]]
 file = "mods/semaphore.pw.toml"
-hash = "d78e99af1cc633034a145fda9389ee63b940c1414351cb44e06a8de874c69763"
+hash = "f32395b4d2a598dc2811bb76dcb945ae643e5f0d19f74850195155fe00f1baa3"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -2238,7 +2238,7 @@ metafile = true
 
 [[files]]
 file = "mods/railways-tweaks.pw.toml"
-hash = "ec662ac7dae5ecebfd7fc56fb33c1e9e28b30afda77d2e57d6c792bcec5b2d68"
+hash = "ebd4a29da89ba29fafb260190915ae71e7477f4f9f6ec3ff1454a4d9317addbe"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -2169,7 +2169,7 @@ metafile = true
 
 [[files]]
 file = "mods/phonos.pw.toml"
-hash = "2c44845294d691881afbe079df41b560d011d45b4fa989a3e29defda77237a04"
+hash = "83da1fc9b40ad6b5ff22837d651ce91484638b9ae64448941e21d406587c4f82"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -2019,7 +2019,7 @@ metafile = true
 
 [[files]]
 file = "mods/moonlight.pw.toml"
-hash = "0b60e339316c855ac576bc8884185c8678e951c39bec99bd1c76106d5efaf573"
+hash = "8833d26bb1840c79ebd7ba91558a28fefef26ec743cb92fcb45372fcdd3a8412"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -1032,7 +1032,7 @@ hash = "0b0e4b8fed893b45deeb1c59a74a421595a8b84ad3a106313079666b75b58ed5"
 
 [[files]]
 file = "kubejs/server_scripts/tags.js"
-hash = "c614147579064cb5886cfb1eff71c5048e6736f52487cb2091b92cc80a167532"
+hash = "8a29f497e7013aa2ed09de77ab3decfa079fa6513cd35b53204f5b79a2988085"
 
 [[files]]
 file = "kubejs/startup_scripts/biofuel_burn_time.js"

--- a/index.toml
+++ b/index.toml
@@ -1032,7 +1032,7 @@ hash = "0b0e4b8fed893b45deeb1c59a74a421595a8b84ad3a106313079666b75b58ed5"
 
 [[files]]
 file = "kubejs/server_scripts/tags.js"
-hash = "8a29f497e7013aa2ed09de77ab3decfa079fa6513cd35b53204f5b79a2988085"
+hash = "c4f3ea626d5dde7d36d19c49bba863bd1080ef01bc4a6259825f7efac82ae0d7"
 
 [[files]]
 file = "kubejs/startup_scripts/biofuel_burn_time.js"

--- a/index.toml
+++ b/index.toml
@@ -90,7 +90,7 @@ hash = "1de5a07a92ed99574f03555597da94db00d30b2f28ead3b1caf9abd86485452b"
 
 [[files]]
 file = "config/item_obliterator.json5"
-hash = "547c2de0085a176a314f1af3b498df027ba98a648ce0dd2b3ffd4806037aa55f"
+hash = "0a7e37d34b441ab744e1ad2b8a16ef8f5cdb16c3f722609ff529f25e634ee253"
 
 [[files]]
 file = "config/lmft.json"
@@ -1032,7 +1032,7 @@ hash = "0b0e4b8fed893b45deeb1c59a74a421595a8b84ad3a106313079666b75b58ed5"
 
 [[files]]
 file = "kubejs/server_scripts/tags.js"
-hash = "8ebd52075665b79664e02c05e28a27220c826b8bbb7bb2d8f1de89c2ce355511"
+hash = "c614147579064cb5886cfb1eff71c5048e6736f52487cb2091b92cc80a167532"
 
 [[files]]
 file = "kubejs/startup_scripts/biofuel_burn_time.js"
@@ -1320,7 +1320,7 @@ metafile = true
 
 [[files]]
 file = "mods/cicada.pw.toml"
-hash = "9429467855b96d1437d6335f45282625c4af182ec760a876f97270d0f2397f5a"
+hash = "62fb498f541daf662929f2e1241fe4fc350af6f90f529de76a8f4a1987b2a756"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -880,7 +880,7 @@ hash = "45d26a6d873bea2dbb9b693865225b218050b3cd61e11a3118c53c6814ed6e3c"
 
 [[files]]
 file = "kubejs/data/spelunkery/loot_tables/gameplay/sluice/lava/passive.json"
-hash = "e4a27bee2c336a8f69cd0fc35dd9c254ab7746e19b9992588e9322e6cb47cca4"
+hash = "0cf169f27673c4555df43451d56572a49fd919d5495b7efdd55a6da58100cab3"
 
 [[files]]
 file = "kubejs/data/spelunkery/loot_tables/gameplay/sluice/portal_fluid/passive.json"

--- a/index.toml
+++ b/index.toml
@@ -2169,7 +2169,7 @@ metafile = true
 
 [[files]]
 file = "mods/phonos.pw.toml"
-hash = "83da1fc9b40ad6b5ff22837d651ce91484638b9ae64448941e21d406587c4f82"
+hash = "89e1aa179b419f31ddc2998a371361fe7ee3c65e87f0242c90d51c4a6900d6f7"
 metafile = true
 
 [[files]]

--- a/kubejs/data/spelunkery/loot_tables/gameplay/sluice/lava/passive.json
+++ b/kubejs/data/spelunkery/loot_tables/gameplay/sluice/lava/passive.json
@@ -79,7 +79,7 @@
                   {
                     "condition": "minecraft:location_check",
                     "predicate": {
-                      "structure": "minecraft:fortress"
+                      "structure": "betterfortresses:fortress"
                     }
                   }
                 ]

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -69,7 +69,7 @@ ServerEvents.tags("block", (event) => {
     });
     // Tinkers budding blocks
     tinkers_crystal_types.forEach((type) => {
-	event.add(`tconstruct:budding_${type}_slime_crystal`);
+	event.add("c:budding_blocks", `tconstruct:budding_${type}_slime_crystal`);
     });
 });
 

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -50,6 +50,13 @@ let non_movable = [
 let bottomless_allow = ["create:honey", "milk:milk_fluid_block"];
 const tinkers_crystal_types = ["earth", "sky", "ichor", "ender"];
 
+const modded_elytras = [
+    "estrogen:moth_elytra",
+    "betterend:elytra_armored",
+    "bettterend:elytra_crystalite",
+    "tconstruct:slime_chestplate"
+]
+
 ServerEvents.tags("block", (event) => {
     better_end_chests.forEach((id) => {
         event.add("lootr:convert/chests", id);
@@ -79,6 +86,8 @@ ServerEvents.tags("fluid", (event) => {
     });
 });
 
+
+
 ServerEvents.tags("item", (event) => {
     // Ore tags
     const ingots = ["copper", "brass", "zinc", "gold", "silver"];
@@ -96,4 +105,9 @@ ServerEvents.tags("item", (event) => {
     // Kirins fuel tags
     event.add("create:blaze_burner_fuel/special", "createaddition:bioethanol_bucket")
     event.add("create:blaze_burner_fuel/regular", "createaddition:seed_oil_bucket")
+
+    // Aileron Enchantment tags
+    modded_elytras.forEach((id) => {
+        event.add("aileron:elytra", id)
+    })
 });

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -48,6 +48,7 @@ let non_movable = [
 ];
 
 let bottomless_allow = ["create:honey", "milk:milk_fluid_block"];
+const tinkers_crystal_types = ["earth", "sky", "ichor", "ender"];
 
 ServerEvents.tags("block", (event) => {
     better_end_chests.forEach((id) => {
@@ -65,6 +66,10 @@ ServerEvents.tags("block", (event) => {
 
     non_movable.forEach((id) => {
         event.add("create:non_movable", id);
+    });
+    // Tinkers budding blocks
+    tinkers_crystal_types.forEach((type) => {
+	event.add(`tconstruct:budding_${type}_slime_crystal`);
     });
 });
 

--- a/mods/cicada.pw.toml
+++ b/mods/cicada.pw.toml
@@ -1,13 +1,13 @@
 name = "CICADA"
-filename = "cicada-lib-0.8.3+1.20.1.jar"
+filename = "cicada-lib-0.13.1+1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/IwCkru1D/versions/Kuqg1f1T/cicada-lib-0.8.3%2B1.20.1.jar"
-hash-format = "sha1"
-hash = "76ec352f974c755e9ae67419ff500cc5f408b932"
+url = "https://cdn.modrinth.com/data/IwCkru1D/versions/bloIrVc5/cicada-lib-0.13.1%2B1.20.1.jar"
+hash-format = "sha512"
+hash = "02f84b18f65b54f03f8c8621410816e93378d45ae00e3cdcaeba658d439bff652cdf5c873b936f6dc88b666d8a1683adc76d784224619a25f01b550a062d10e8"
 
 [update]
 [update.modrinth]
 mod-id = "IwCkru1D"
-version = "Kuqg1f1T"
+version = "bloIrVc5"

--- a/mods/moonlight.pw.toml
+++ b/mods/moonlight.pw.toml
@@ -1,13 +1,13 @@
 name = "Moonlight Lib"
-filename = "moonlight-1.20-2.13.83-fabric.jar"
+filename = "moonlight-1.20-2.14.11-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/twkfQtEc/versions/dM3MIOxs/moonlight-1.20-2.13.83-fabric.jar"
+url = "https://cdn.modrinth.com/data/twkfQtEc/versions/GVVbixH6/moonlight-1.20-2.14.11-fabric.jar"
 hash-format = "sha512"
-hash = "3bb67608142979215b51c5ffc29318001776408c1b47e385b5dc473d78b30c47324b9ca48f24bf9247f549f4aef501157d242f6850f592e0d0cb8987f9ebb27c"
+hash = "0c0bb8cde5b72bcb6075151d0cd1f6f92dff9d36bb05d2011990ecb25c6d7082892e278ec47de7cb94d729b863e75bab653c6f86cf9f2b5480ed7b163aaf4275"
 
 [update]
 [update.modrinth]
 mod-id = "twkfQtEc"
-version = "dM3MIOxs"
+version = "GVVbixH6"

--- a/mods/phonos.pw.toml
+++ b/mods/phonos.pw.toml
@@ -1,7 +1,7 @@
 name = "phonos"
-filename = "phonos-1.0.0-beta.38+fabric-1.20.1.jar"
+filename = "phonos-1.0.0-beta.39+fabric-1.20.1.jar"
 
 [download]
-url = "https://github.com/Layers-of-Railways/Phonos/releases/download/1.0.0-beta.38%2B1.20.1/phonos-1.0.0-beta.38+fabric-1.20.1.jar"
+url = "https://github.com/Layers-of-Railways/Phonos/releases/download/1.0.0-beta.39%2B1.20.1/phonos-1.0.0-beta.39+fabric-1.20.1.jar"
 hash-format = "sha256"
-hash = "5825f281a4f55606b36db3df2d575674f390f3a9a7c27ce244d22c458b348d70"
+hash = "188336ff65f1f6b03b255dd72b681cb81f08255f374f2de93912dc36dfacf6b8"

--- a/mods/phonos.pw.toml
+++ b/mods/phonos.pw.toml
@@ -1,7 +1,7 @@
 name = "phonos"
-filename = "phonos-1.0.0-beta.37+fabric-1.20.1.jar"
+filename = "phonos-1.0.0-beta.38+fabric-1.20.1.jar"
 
 [download]
-url = "https://github.com/Layers-of-Railways/Phonos/releases/download/1.0.0-beta.37%2B1.20.1/phonos-1.0.0-beta.37+fabric-1.20.1.jar"
+url = "https://github.com/Layers-of-Railways/Phonos/releases/download/1.0.0-beta.38%2B1.20.1/phonos-1.0.0-beta.38+fabric-1.20.1.jar"
 hash-format = "sha256"
-hash = "4dca4b045d3e14b305839468cf2d4d349127f67ab87364060ceb303c719012d6"
+hash = "5825f281a4f55606b36db3df2d575674f390f3a9a7c27ce244d22c458b348d70"

--- a/mods/railways-tweaks.pw.toml
+++ b/mods/railways-tweaks.pw.toml
@@ -1,7 +1,7 @@
 name = "railways-tweaks"
-filename = "RailwaysTweaks-0.1.16.jar"
+filename = "RailwaysTweaks-0.1.26.jar"
 
 [download]
-url = "https://github.com/Layers-of-Railways/RailwaysTweaks/releases/download/v0.1.16/RailwaysTweaks-0.1.16.jar"
+url = "https://github.com/Layers-of-Railways/RailwaysTweaks/releases/download/v0.1.26/RailwaysTweaks-0.1.26.jar"
 hash-format = "sha256"
-hash = "97d3eda756feb7cbee47a1518aa48812aacbb623b290de5529cc0590854eecec"
+hash = "5c8d4d416f96b6d096270446e718a7d084708e3708a534b5c0704f5762b724e5"

--- a/mods/semaphore.pw.toml
+++ b/mods/semaphore.pw.toml
@@ -1,7 +1,7 @@
 name = "semaphore"
-filename = "Semaphore-0.1.2-beta.2+fabric-mc1.20.1-build.18.jar"
+filename = "Semaphore-0.1.2-beta.3+fabric-mc1.20.1-build.22.jar"
 
 [download]
-url = "https://github.com/Layers-of-Railways/Semaphore/releases/download/v0.1.2-beta.2/Semaphore-0.1.2-beta.2+fabric-mc1.20.1-build.18.jar"
+url = "https://github.com/Layers-of-Railways/Semaphore/releases/download/v0.1.2-beta.3/Semaphore-0.1.2-beta.3+fabric-mc1.20.1-build.22.jar"
 hash-format = "sha256"
-hash = "7851d8f1876e43ab727ae7a45d6cc9129b754a3ab62e999456874f9fcfcda692"
+hash = "95d9d6814cb1ee1418fa9d2f626ac05cfcc4f7e0771de16adf15f3107b84cc7e"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "78371079049ab1740788c530382a6af51c272639898ffadc8d4fbfe804850d5c"
+hash = "9e8d484a2457a8b45b55b5c57751af5e48cfd1843fb5f5c06a3e2e5bf040053d"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "99ac970cf897e05dbd64db7978e8486e54f2e83fd18f748f446d6ccf84e669e2"
+hash = "48fc586cb958baffbc3a06cb95dc009287c7ee1c963d46f308e8697cf2818342"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "32453e36b04cad5a710eaaa62e0dcdb8c91a7782077233b3bf88ebc8608ac59c"
+hash = "47e6e921621a4d23ada184cfffc91d673b75dbd2699277bad8f6188ced7a13f6"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0882117d2e6be4224580f4b36a0579d99b235c3c2c0235c396afddaf0f3dae07"
+hash = "266f6d551f0804612b533a81bf257ef1b01fc3a9e5c1a7b6f2cbeef38f326dd6"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "266f6d551f0804612b533a81bf257ef1b01fc3a9e5c1a7b6f2cbeef38f326dd6"
+hash = "e21650d1b44eb4f2f71d3f0614dd019875bf616f7bfcc282414458de01b6e225"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "Steam 'n' Rails Modpack"
 author = "IThundxr"
-version = "1.6.4"
+version = "1.6.5"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "9e8d484a2457a8b45b55b5c57751af5e48cfd1843fb5f5c06a3e2e5bf040053d"
+hash = "32453e36b04cad5a710eaaa62e0dcdb8c91a7782077233b3bf88ebc8608ac59c"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "9c9ef98052b6d0ba311d2cc8449658cf999fe092029b8918507d8e06701396d9"
+hash = "78371079049ab1740788c530382a6af51c272639898ffadc8d4fbfe804850d5c"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "e21650d1b44eb4f2f71d3f0614dd019875bf616f7bfcc282414458de01b6e225"
+hash = "99ac970cf897e05dbd64db7978e8486e54f2e83fd18f748f446d6ccf84e669e2"
 
 [versions]
 fabric = "0.16.14"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "47e6e921621a4d23ada184cfffc91d673b75dbd2699277bad8f6188ced7a13f6"
+hash = "0882117d2e6be4224580f4b36a0579d99b235c3c2c0235c396afddaf0f3dae07"
 
 [versions]
 fabric = "0.16.14"


### PR DESCRIPTION
- Major improvements to Basin recipe matching speeds which should significantly reduce lag. Courtesy of Slimeist <3
- Improvements to logging and synchronisation within Phonos to try to prevent Microphone audio being transmitted over to radio to those who aren't tuned in.
- Sluicing now works in Better Nether Fortresses.
- Updated Cicada to fix capes
- Fixed Growth Accelerators not working with Tinkers budding blocks #75 
- Allow Ailreon enchants such as Cloudskipper to be applied to Modded Elytras #55 
- Removed the Rose Hip Pie item to prevent a crash #78 
- Fixed issues with the change in ip address with Xaeros World Map and Bluemap
