### PR TITLE
Add recipes for turning slabs back into blocks

### DIFF
--- a/kubejs/server_scripts/recipes/slabs.js
+++ b/kubejs/server_scripts/recipes/slabs.js
@@ -1,4 +1,4 @@
-ServerEvents.recipes(event => {
+ServerEvents.recipes((event) => {
   event.forEachRecipe({ type: 'minecraft:crafting_shaped' }, r => {
     let output = r.getOriginalRecipeResult()
     let slab = output.getId()

--- a/kubejs/server_scripts/recipes/slabs.json
+++ b/kubejs/server_scripts/recipes/slabs.json
@@ -1,0 +1,25 @@
+ServerEvents.recipes(event => {
+  event.forEachRecipe({ type: 'minecraft:crafting_shaped' }, r => {
+    let output = r.getOriginalRecipeResult()
+    let slab = output.getId()
+    if(!slab.includes('slab')) return
+    let recipeJson = r.json
+    if(!recipeJson.has('pattern')) return
+    let pattern = recipeJson.get('pattern')
+    if(pattern.size()>1) return
+    let shape = pattern.get(0).getAsString().split('')
+    if(shape[0] != shape[1] || shape[1] != shape[2]) return
+    let ingredientKey = JSON.parse(recipeJson.get('key'))[shape[0]]
+    if(ingredientKey.tag) return
+    let ingredient = ingredientKey.item || ingredientKey[0].item
+    
+    event.shaped(
+      Item.of(ingredient, 3),
+      [
+        'AAA',
+        'AAA'
+      ],
+      { A: slab }
+    )
+  })
+})


### PR DESCRIPTION
As requested in [this thread](https://discord.com/channels/706277846389227612/1473742796790824981), this kubejs script finds all slab recipes from crafting and then adds a recipe for each one back into the original block.
There are some unique cases though:
- If the input of a recipe is a tag, I couldn't find a way to get items with a tag (at least not so early in the loading process), so there won't be any reverse recipe (this applies to: `suppsquared:daub_frame_slab` and `consistency_plus:copper_slab`)
- If there are multiple possible inputs of a recipe (but it's an array not a tag!), it just grabs the first possible input and that's the output of turning a slab back into a block (this applies to: `minecraft:quartz_slab`, `minecraft:red_sandstone_slab`, `minecraft:purpur_slab`, `minecraft:sandstone_slab`, `betterend:thallasium_slab`, `betterend:terminite_slab` and `natures_spirit:pink_sandstone_slab`)

**Disclaimer:** KubeJS is poorly documented, so I used the help of AI for:
- getting all recipes
- filtering the recipes to only get slab ones
- getting ingredients and outputs of a recipe

I'm not a fan of AI, but I didn't have the energy to manually dig through KubeJS source code to find how certain things work
**Note:** The OP of the thread wanted a shapeless recipe, not a shaped recipe from 6 slabs into 3 blocks like in this script. I can easily change that recipe, however I'd rather have the mods decide on how it should be.